### PR TITLE
Add 'sir' shadow to Section component

### DIFF
--- a/components/common/Section.vue
+++ b/components/common/Section.vue
@@ -11,7 +11,7 @@ const classes = computed(() => {
   return classLink([
     'rounded-lg',
     props.variant === 'ring' ? 'ring-2 ring-gray-800' : '',
-    props.variant === 'background' ? 'bg-black-russian-950' : '',
+    props.variant === 'background' ? 'bg-black-russian-950 shadow-sir' : '',
     'p-3 md:p-8 my-12',
     props.className ? props.className : ''
   ])

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,6 +9,7 @@ export default <Partial<Config>>{
       },
       boxShadow: {
         'md': '0px 4px 4px rgba(0, 0, 0, 0.25)',
+        'sir': '2px 4px 10px rgba(0, 0, 0, 0.5)',
       },
       blur: {
         '12px': '12px',


### PR DESCRIPTION
Introduced a new shadow class 'sir' in the Tailwind configuration. Updated the Section component to use this new shadow when the 'background' variant is applied.