### PR TITLE
BugFix: stablecoin lock

### DIFF
--- a/components/sale/ContributeForm.vue
+++ b/components/sale/ContributeForm.vue
@@ -191,7 +191,7 @@ const doLockNfts = async () => {
 
 
 const lockMenuInput = computed(() => {
-  return saleStore.contributions.timeLastContribution > 0 && saleStore.contributions.amountWithdrawableNoDecimals > 0
+  return saleStore.contributions.timeLastContribution > 0 && (saleStore.contributions.amountWithdrawableNoDecimals > 0 || saleStore.contributions.amountFinalNoDecimals > 0)
 })
 
 if (lockMenuInput.value) {


### PR DESCRIPTION
Modified the condition for `lockMenuInput` to also consider `amountFinalNoDecimals` when determining if the menu should be locked. This ensures that the input remains locked when there are final amounts available.