### PR TITLE
Update progress bar text for clarity

### DIFF
--- a/components/common/SirProgressBar.vue
+++ b/components/common/SirProgressBar.vue
@@ -29,7 +29,7 @@ const value = asyncComputed(async () => {
         class="rounded-md progress-gradient h-[40px] transition-width duration-1000 ease-out"
         :style="{ width: value + '%' }"
     >
-      <div class="indicator title sir-text-shadow-darker text-lg">{{ value }}% $500K RAISED</div>
+      <div class="indicator title sir-text-shadow-darker text-lg">{{ value }}% OF $500K RAISED</div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Changed the text within the progress bar indicator to clarify the fundraising progress, now displaying "{{ value }}% OF $500K RAISED" instead of the previous "{{ value }}% $500K RAISED", providing a clearer message about the progress towards the fundraising goal.