### PR TITLE
Add configurable manual sale limit to sale logic

### DIFF
--- a/components/common/SirProgressBar.vue
+++ b/components/common/SirProgressBar.vue
@@ -6,11 +6,22 @@ import { useSaleStore } from "~/stores/sale";
 const eth = useEthClient();
 const maxContribution = await eth.maxContributions();
 const saleStore = useSaleStore();
+const {manualSaleLimit} = useRuntimeConfig().public;
+const saleLimit :number = manualSaleLimit ? parseInt(manualSaleLimit) : maxContribution;
+console.log("saleLimit", saleLimit)
 saleStore.fetchSaleState();
 const value = asyncComputed(async () => {
-  const progress = Math.round(saleStore.getTotalContributions / 100000 * 100);
+  const progress = Math.round(saleStore.getTotalContributions / saleLimit * 100);
   return Math.min(progress, 100); // Ensure value does not exceed 100
 }); // Change type to number for proper ARIA handling
+
+const formatSaleLimit = (): string => {
+  if(saleLimit >= 1000) {
+    return `${(saleLimit / 1000).toFixed(0)}K`;
+  }
+  return `${saleLimit}`;
+
+}
 </script>
 
 <template>
@@ -30,7 +41,7 @@ const value = asyncComputed(async () => {
         class="rounded-md progress-gradient h-[40px] transition-width duration-1000 ease-out"
         :style="{ width: value + '%' }"
     >
-      <div class="indicator title sir-text-shadow-darker text-lg">{{ value }}% OF $100K RAISED</div>
+      <div class="indicator title sir-text-shadow-darker text-lg">{{ value }}% OF {{formatSaleLimit()}} RAISED</div>
     </div>
   </div>
 </template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -20,7 +20,8 @@ export default defineNuxtConfig({
       env: process.env.NUXT_ENV,
       buterinCards: process.env.NUXT_BUTERIN_CARDS,
       minedJpeg: process.env.NUXT_MINED_JPEG,
-      rpc: process.env.NUXT_RPC
+      rpc: process.env.NUXT_RPC,
+      manualSaleLimit: process.env.NUXT_MANUAL_SALE_LIMIT || "1_000",
     },
 
   },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -21,7 +21,7 @@ export default defineNuxtConfig({
       buterinCards: process.env.NUXT_BUTERIN_CARDS,
       minedJpeg: process.env.NUXT_MINED_JPEG,
       rpc: process.env.NUXT_RPC,
-      manualSaleLimit: process.env.NUXT_MANUAL_SALE_LIMIT || "1_000",
+      manualSaleLimit: process.env.NUXT_MANUAL_SALE_LIMIT || "100_000",
     },
 
   },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -21,7 +21,7 @@ export default defineNuxtConfig({
       buterinCards: process.env.NUXT_BUTERIN_CARDS,
       minedJpeg: process.env.NUXT_MINED_JPEG,
       rpc: process.env.NUXT_RPC,
-      manualSaleLimit: process.env.NUXT_MANUAL_SALE_LIMIT || "100_000",
+      manualSaleLimit: process.env.NUXT_MANUAL_SALE_LIMIT || "100000",
     },
 
   },

--- a/pages/sale.vue
+++ b/pages/sale.vue
@@ -11,7 +11,7 @@ import {useNfts} from "~/composables/useNfts";
 const {isConnected, address} = useWallet();
 const nfts = useNfts();
 const saleStore = useSaleStore();
-
+console.log("sale total contributions: ", saleStore.saleState.totalContributions)
 const hasSaleEnded = computed(() => {
   return saleStore.hasSaleEnded
 })

--- a/stores/sale.ts
+++ b/stores/sale.ts
@@ -60,7 +60,11 @@ export const useSaleStore = defineStore('sale', {
       return mapSelectedItems(state.selectedItems, "MJ");
     },
     getTotalContributions: (state): number => state.saleState.totalContributions,
-    hasSaleEnded: (state): boolean => state.saleState.timeSaleEnded > 0,
+    hasSaleEnded: (state): boolean => {
+      const {manualSaleLimit} = useRuntimeConfig().public
+      return state.saleState.timeSaleEnded > 0 ||
+          !!manualSaleLimit && state.saleState.totalContributions >= parseInt(manualSaleLimit)
+    },
     itemsLocked: (state): number => {
       const bc = !!state.contributions.lockedButerinCards.amount ? state.contributions.lockedButerinCards.amount : 0;
       const mj = !!state.contributions.lockedMinedJpegs ? state.contributions.lockedMinedJpegs.amount : 0;


### PR DESCRIPTION
Introduced a `manualSaleLimit` from runtime configuration to dynamically control the sale limit. Updated related computations in sale logic, progress bar, and conditional checks to respect this limit. Also improved progress bar label to reflect the adjusted sale cap.